### PR TITLE
fix: SourceBucket optional fields

### DIFF
--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -39,8 +39,8 @@ class DataAssetOrigin(StrEnum):
 @dataclass(frozen=True)
 class SourceBucket:
     origin: DataAssetOrigin
-    bucket: str
-    prefix: str
+    bucket: Optional[str] = None
+    prefix: Optional[str] = None
     external: Optional[bool] = None
 
 

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -41,7 +41,7 @@ class SourceBucket:
     origin: DataAssetOrigin
     bucket: str
     prefix: str
-    external: bool
+    external: Optional[bool] = None
 
 
 @dataclass_json


### PR DESCRIPTION
Mark optional fields in the SourceBucket data assets API param 