### PR TITLE
feat: makes polling interval configurable

### DIFF
--- a/src/codeocean/computation.py
+++ b/src/codeocean/computation.py
@@ -141,17 +141,18 @@ class Computations:
 
         return Computation.from_dict(res.json())
 
-    def wait_until_completed(self, computation: Computation) -> Computation:
+    def wait_until_completed(self, computation: Computation, polling_interval: int = 5) -> Computation:
         """
         Polls the given computation until it reaches the 'Completed' or 'Failed' state.
         """
+        assert polling_interval >= 5, "polling_interval should be greater than or equal to 5"
         while True:
             comp = self.get_computation(computation.id)
 
             if comp.state in [ComputationState.Completed, ComputationState.Failed]:
                 return comp
 
-            sleep(5)
+            sleep(polling_interval)
 
     def list_computation_results(self, computation_id: str, path: str = "") -> Folder:
         data = {

--- a/src/codeocean/computation.py
+++ b/src/codeocean/computation.py
@@ -145,7 +145,7 @@ class Computations:
         """
         Polls the given computation until it reaches the 'Completed' or 'Failed' state.
         """
-        if polling_interval >= 5:
+        if polling_interval < 5:
             raise ValueError(
                 f"Polling interval {polling_interval} should be greater than or equal to 5"
             )

--- a/src/codeocean/computation.py
+++ b/src/codeocean/computation.py
@@ -145,7 +145,10 @@ class Computations:
         """
         Polls the given computation until it reaches the 'Completed' or 'Failed' state.
         """
-        assert polling_interval >= 5, "polling_interval should be greater than or equal to 5"
+        if polling_interval >= 5:
+            raise ValueError(
+                f"Polling interval {polling_interval} should be greater than or equal to 5"
+            )
         while True:
             comp = self.get_computation(computation.id)
 

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -241,7 +241,10 @@ class DataAssets:
         """
         Polls the given data asset until it reaches the 'Ready' or 'Failed' state.
         """
-        assert polling_interval >= 5, "polling_interval should be greater than or equal to 5"
+        if polling_interval >= 5:
+            raise ValueError(
+                f"Polling interval {polling_interval} should be greater than or equal to 5"
+            )
         while True:
             da = self.get_data_asset(data_asset.id)
 

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -237,17 +237,18 @@ class DataAssets:
 
         return DataAsset.from_dict(res.json())
 
-    def wait_until_ready(self, data_asset: DataAsset) -> DataAsset:
+    def wait_until_ready(self, data_asset: DataAsset, polling_interval: int = 5) -> DataAsset:
         """
         Polls the given data asset until it reaches the 'Ready' or 'Failed' state.
         """
+        assert polling_interval >= 5, "polling_interval should be greater than or equal to 5"
         while True:
             da = self.get_data_asset(data_asset.id)
 
             if da.state in [DataAssetState.Ready, DataAssetState.Failed]:
                 return da
 
-            sleep(5)
+            sleep(polling_interval)
 
     def delete_data_asset(self, data_asset_id: str):
         self.client.delete(f"data_assets/{data_asset_id}")

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -241,7 +241,7 @@ class DataAssets:
         """
         Polls the given data asset until it reaches the 'Ready' or 'Failed' state.
         """
-        if polling_interval >= 5:
+        if polling_interval < 5:
             raise ValueError(
                 f"Polling interval {polling_interval} should be greater than or equal to 5"
             )


### PR DESCRIPTION
Closes #11 

- Makes the polling interval configurable so users can increase the interval for long running computations
- Sets `5` as the default to be backwards compatible
- Adds an `assert` so users can't decrease the interval below `5`