### PR TITLE
feat: adds option for custom adapters

### DIFF
--- a/src/codeocean/client.py
+++ b/src/codeocean/client.py
@@ -1,9 +1,9 @@
-from typing import Tuple
-
-from requests_toolbelt.sessions import BaseUrlSession
+from dataclasses import dataclass
 from requests_toolbelt.adapters.socket_options import TCPKeepAliveAdapter
+from requests_toolbelt.sessions import BaseUrlSession
 from requests.adapters import HTTPAdapter
-from dataclasses import dataclass, field
+from typing import Optional
+from urllib3.util import Retry
 
 from codeocean.capsule import Capsules
 from codeocean.computation import Computations
@@ -15,20 +15,17 @@ class CodeOcean:
 
     domain: str
     token: str
-    _optional_adapters: Tuple[HTTPAdapter] = field(default=tuple(), repr=False)
+    retries: Optional[Retry] = None
 
     def __post_init__(self):
         self.session = BaseUrlSession(base_url=f"{self.domain}/api/v1/")
         self.session.auth = (self.token, "")
-        self.session.mount(self.domain, TCPKeepAliveAdapter())
-
-        for optional_adapter in self._optional_adapters:
-            self.session.mount(self.domain, optional_adapter)
         self.session.headers.update({"Content-Type": "application/json"})
         self.session.hooks["response"] = [
             lambda response, *args, **kwargs: response.raise_for_status()
         ]
-
+        self.session.mount(self.domain, TCPKeepAliveAdapter(max_retries=self.retries))
+        
         self.capsules = Capsules(client=self.session)
         self.computations = Computations(client=self.session)
         self.data_assets = DataAssets(client=self.session)

--- a/src/codeocean/client.py
+++ b/src/codeocean/client.py
@@ -1,6 +1,9 @@
+from typing import Tuple
+
 from requests_toolbelt.sessions import BaseUrlSession
 from requests_toolbelt.adapters.socket_options import TCPKeepAliveAdapter
-from dataclasses import dataclass
+from requests.adapters import HTTPAdapter
+from dataclasses import dataclass, field
 
 from codeocean.capsule import Capsules
 from codeocean.computation import Computations
@@ -12,11 +15,15 @@ class CodeOcean:
 
     domain: str
     token: str
+    _optional_adapters: Tuple[HTTPAdapter] = field(default=tuple(), repr=False)
 
     def __post_init__(self):
         self.session = BaseUrlSession(base_url=f"{self.domain}/api/v1/")
         self.session.auth = (self.token, "")
         self.session.mount(self.domain, TCPKeepAliveAdapter())
+
+        for optional_adapter in self._optional_adapters:
+            self.session.mount(self.domain, optional_adapter)
         self.session.headers.update({"Content-Type": "application/json"})
         self.session.hooks["response"] = [
             lambda response, *args, **kwargs: response.raise_for_status()

--- a/src/codeocean/client.py
+++ b/src/codeocean/client.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from requests_toolbelt.adapters.socket_options import TCPKeepAliveAdapter
 from requests_toolbelt.sessions import BaseUrlSession
-from requests.adapters import HTTPAdapter
 from typing import Optional
 from urllib3.util import Retry
 
@@ -25,7 +24,7 @@ class CodeOcean:
             lambda response, *args, **kwargs: response.raise_for_status()
         ]
         self.session.mount(self.domain, TCPKeepAliveAdapter(max_retries=self.retries))
-        
+
         self.capsules = Capsules(client=self.session)
         self.computations = Computations(client=self.session)
         self.data_assets = DataAssets(client=self.session)


### PR DESCRIPTION
Closes #12 

- Adds `_optional_adapters` field to CodeOcean data class. Default is empty tuple. Suppressed from class repr.
- Mounts adapters in `__post_init__`