### PR TITLE
fix: revert default number of retries to 0

### DIFF
--- a/src/codeocean/client.py
+++ b/src/codeocean/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from requests_toolbelt.adapters.socket_options import TCPKeepAliveAdapter
 from requests_toolbelt.sessions import BaseUrlSession

--- a/src/codeocean/client.py
+++ b/src/codeocean/client.py
@@ -14,7 +14,7 @@ class CodeOcean:
 
     domain: str
     token: str
-    retries: Optional[Retry] = None
+    retries: Optional[Retry | int] = 0
 
     def __post_init__(self):
         self.session = BaseUrlSession(base_url=f"{self.domain}/api/v1/")


### PR DESCRIPTION
https://github.com/codeocean/codeocean-sdk-python/pull/15 added an option for custom number of retries, however it also changed the default number of retries from 0 to 3 (details on the PR).

This PR:
- reverts the default number of retries back to 0
- adds `int` as a valid type on the `retries` field 
  - `Retry`, `int` and `None` are all valid so `Optional[...]` is still technically correct, but the behavior for `None` is somewhat surprising

This might not be deemed necessary - please feel free to close it.