### PR TITLE
feat: support pagination in search data API, model type 

### DIFF
--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -204,6 +204,7 @@ class DataAssetSearchParams:
     archived: bool
     favorite: bool
     query: Optional[str] = None
+    next_token: Optional[str] = None
     sort_field: Optional[DataAssetSortBy] = None
     sort_order: Optional[SortOrder] = None
     type: Optional[DataAssetType] = None
@@ -217,6 +218,7 @@ class DataAssetSearchParams:
 class DataAssetSearchResults:
     has_more: bool
     results: list[DataAsset]
+    next_token: Optional[str] = None
 
 
 @dataclass_json

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -15,6 +15,7 @@ class DataAssetType(StrEnum):
     Dataset = "dataset"
     Result = "result"
     Combined = "combined"
+    Model = "model"
 
 
 class DataAssetState(StrEnum):

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -199,10 +199,10 @@ class DataAssetSearchOrigin(StrEnum):
 @dataclass_json
 @dataclass(frozen=True)
 class DataAssetSearchParams:
-    limit: int
-    offset: int
-    archived: bool
-    favorite: bool
+    limit: Optional[int] = None
+    offset: Optional[int] = None
+    archived: Optional[bool] = None
+    favorite: Optional[bool] = None
     query: Optional[str] = None
     next_token: Optional[str] = None
     sort_field: Optional[DataAssetSortBy] = None


### PR DESCRIPTION
- add next_token field to DataAssetSearchParams and DataAssetSearchResults to support pagination of data asset search (added in 3.1)
- make all DataAssetSearchParams optional inline with OpenAPI spec 
- add "model" as a DataAssetType (added in 3.1)