### PR TITLE
feat: add capsule search api

### DIFF
--- a/src/codeocean/capsule.py
+++ b/src/codeocean/capsule.py
@@ -114,7 +114,7 @@ class Capsules:
             f"capsules/{capsule_id}/data_assets/",
             json=data_assets,
         )
-    
+
     def search_capsules(self, search_params: CapsuleSearchParams) -> CapsuleSearchResults:
         res = self.client.post("capsules/search", json=search_params.to_dict())
 

--- a/src/codeocean/capsule.py
+++ b/src/codeocean/capsule.py
@@ -49,6 +49,30 @@ class Capsule:
     versions: Optional[list[dict]] = None
 
 
+@dataclass_json
+@dataclass(frozen=True)
+class CapsuleSearchParams:
+    query: Optional[str] = None
+    next_token: Optional[str] = None
+    offset: Optional[int] = None
+    limit: Optional[int] = None
+    sort_field: Optional[CapsuleSortBy] = None
+    sort_order: Optional[SortOrder] = None
+    ownership: Optional[CapsuleOwnership] = None
+    status: Optional[CapsuleStatus] = None
+    favorite: Optional[bool] = None
+    archived: Optional[bool] = None
+    filters: Optional[list[SearchFilter]] = None
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class CapsuleSearchResults:
+    has_more: bool
+    results: list[Capsule]
+    next_token: Optional[str] = None
+
+
 @dataclass
 class Capsules:
 
@@ -80,3 +104,8 @@ class Capsules:
             f"capsules/{capsule_id}/data_assets/",
             json=data_assets,
         )
+    
+    def search_capsules(self, search_params: CapsuleSearchParams) -> CapsuleSearchResults:
+        res = self.client.post("capsules/search", json=search_params.to_dict())
+
+        return CapsuleSearchResults.from_dict(res.json())

--- a/src/codeocean/capsule.py
+++ b/src/codeocean/capsule.py
@@ -17,6 +17,10 @@ class CapsuleStatus(StrEnum):
     Published = "published"
     Verified = "verified"
 
+class CapsuleSortBy(StrEnum):
+    Created = "created"
+    LastAccessed = "last_accessed"
+    Name = "name"
 
 @dataclass_json
 @dataclass(frozen=True)
@@ -58,7 +62,7 @@ class CapsuleSearchParams:
     limit: Optional[int] = None
     sort_field: Optional[CapsuleSortBy] = None
     sort_order: Optional[SortOrder] = None
-    ownership: Optional[CapsuleOwnership] = None
+    ownership: Optional[Ownership] = None
     status: Optional[CapsuleStatus] = None
     favorite: Optional[bool] = None
     archived: Optional[bool] = None

--- a/src/codeocean/capsule.py
+++ b/src/codeocean/capsule.py
@@ -5,6 +5,7 @@ from dataclasses_json import dataclass_json
 from typing import Optional
 from requests_toolbelt.sessions import BaseUrlSession
 
+from codeocean.components import SortOrder, SearchFilter
 from codeocean.computation import Computation
 from codeocean.data_asset import DataAssetAttachParams, DataAssetAttachResults
 from codeocean.enum import StrEnum
@@ -17,10 +18,18 @@ class CapsuleStatus(StrEnum):
     Published = "published"
     Verified = "verified"
 
+
 class CapsuleSortBy(StrEnum):
     Created = "created"
     LastAccessed = "last_accessed"
     Name = "name"
+
+
+class CapsuleOwnership(StrEnum):
+    Private = "private"
+    Shared = "shared"
+    Created = "created"
+
 
 @dataclass_json
 @dataclass(frozen=True)
@@ -62,7 +71,7 @@ class CapsuleSearchParams:
     limit: Optional[int] = None
     sort_field: Optional[CapsuleSortBy] = None
     sort_order: Optional[SortOrder] = None
-    ownership: Optional[Ownership] = None
+    ownership: Optional[CapsuleOwnership] = None
     status: Optional[CapsuleStatus] = None
     favorite: Optional[bool] = None
     archived: Optional[bool] = None

--- a/src/codeocean/capsule.py
+++ b/src/codeocean/capsule.py
@@ -12,11 +12,8 @@ from codeocean.enum import StrEnum
 
 
 class CapsuleStatus(StrEnum):
-    NonPublished = "non-published"
-    Submitted = "submitted"
-    Publishing = "publishing"
-    Published = "published"
-    Verified = "verified"
+    NonRelease = "non_release"
+    Release = "release"
 
 
 class CapsuleSortBy(StrEnum):
@@ -55,9 +52,9 @@ class Capsule:
     cloned_from_url: Optional[str] = None
     description: Optional[str] = None
     field: Optional[str] = None
-    keywords: Optional[list[str]] = None
+    tags: Optional[list[str]] = None
     original_capsule: Optional[OriginalCapsuleInfo] = None
-    published_capsule: Optional[str] = None
+    release_capsule: Optional[str] = None
     submission: Optional[dict] = None
     versions: Optional[list[dict]] = None
 

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -204,6 +204,7 @@ class DataAssetSearchParams:
     archived: bool
     favorite: bool
     query: Optional[str] = None
+    next_token: Optional[str] = None
     sort_field: Optional[DataAssetSortBy] = None
     sort_order: Optional[SortOrder] = None
     type: Optional[DataAssetType] = None
@@ -217,6 +218,7 @@ class DataAssetSearchParams:
 class DataAssetSearchResults:
     has_more: bool
     results: list[DataAsset]
+    next_token: Optional[str] = None
 
 
 @dataclass_json

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -15,6 +15,7 @@ class DataAssetType(StrEnum):
     Dataset = "dataset"
     Result = "result"
     Combined = "combined"
+    Model = "model"
 
 
 class DataAssetState(StrEnum):

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -199,10 +199,10 @@ class DataAssetSearchOrigin(StrEnum):
 @dataclass_json
 @dataclass(frozen=True)
 class DataAssetSearchParams:
-    limit: int
-    offset: int
-    archived: bool
-    favorite: bool
+    limit: Optional[int] = None
+    offset: Optional[int] = None
+    archived: Optional[bool] = None
+    favorite: Optional[bool] = None
     query: Optional[str] = None
     next_token: Optional[str] = None
     sort_field: Optional[DataAssetSortBy] = None


### PR DESCRIPTION
- add support for capsule search API, introduced in v3.1
- update Capsule and CapsuleStatus fields according to v3.1 changes:
     - published_capsule --> release_capsule
     - keywords --> tags