### PR TITLE
feat: Code Ocean Version 3.1 updates

### DIFF
--- a/src/codeocean/capsule.py
+++ b/src/codeocean/capsule.py
@@ -22,12 +22,6 @@ class CapsuleSortBy(StrEnum):
     Name = "name"
 
 
-class Ownership(StrEnum):
-    Private = "private"
-    Shared = "shared"
-    Created = "created"
-
-
 @dataclass_json
 @dataclass(frozen=True)
 class OriginalCapsuleInfo:

--- a/src/codeocean/capsule.py
+++ b/src/codeocean/capsule.py
@@ -5,7 +5,7 @@ from dataclasses_json import dataclass_json
 from typing import Optional
 from requests_toolbelt.sessions import BaseUrlSession
 
-from codeocean.components import SortOrder, SearchFilter
+from codeocean.components import Ownership, SortOrder, SearchFilter
 from codeocean.computation import Computation
 from codeocean.data_asset import DataAssetAttachParams, DataAssetAttachResults
 from codeocean.enum import StrEnum
@@ -22,7 +22,7 @@ class CapsuleSortBy(StrEnum):
     Name = "name"
 
 
-class CapsuleOwnership(StrEnum):
+class Ownership(StrEnum):
     Private = "private"
     Shared = "shared"
     Created = "created"
@@ -68,7 +68,7 @@ class CapsuleSearchParams:
     limit: Optional[int] = None
     sort_field: Optional[CapsuleSortBy] = None
     sort_order: Optional[SortOrder] = None
-    ownership: Optional[CapsuleOwnership] = None
+    ownership: Optional[Ownership] = None
     status: Optional[CapsuleStatus] = None
     favorite: Optional[bool] = None
     archived: Optional[bool] = None

--- a/src/codeocean/capsule.py
+++ b/src/codeocean/capsule.py
@@ -114,7 +114,7 @@ class Capsules:
             f"capsules/{capsule_id}/data_assets/",
             json=data_assets,
         )
-    
+
     def search_capsules(self, search_params: CapsuleSearchParams) -> CapsuleSearchResults:
         res = self.client.post("capsules/search", json=search_params.to_dict())
 

--- a/src/codeocean/capsule.py
+++ b/src/codeocean/capsule.py
@@ -49,6 +49,30 @@ class Capsule:
     versions: Optional[list[dict]] = None
 
 
+@dataclass_json
+@dataclass(frozen=True)
+class CapsuleSearchParams:
+    query: Optional[str] = None
+    next_token: Optional[str] = None
+    offset: Optional[int] = None
+    limit: Optional[int] = None
+    sort_field: Optional[CapsuleSortBy] = None
+    sort_order: Optional[SortOrder] = None
+    ownership: Optional[CapsuleOwnership] = None
+    status: Optional[CapsuleStatus] = None
+    favorite: Optional[bool] = None
+    archived: Optional[bool] = None
+    filters: Optional[list[SearchFilter]] = None
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class CapsuleSearchResults:
+    has_more: bool
+    results: list[Capsule]
+    next_token: Optional[str] = None
+
+
 @dataclass
 class Capsules:
 
@@ -80,3 +104,8 @@ class Capsules:
             f"capsules/{capsule_id}/data_assets/",
             json=data_assets,
         )
+    
+    def search_capsules(self, search_params: CapsuleSearchParams) -> CapsuleSearchResults:
+        res = self.client.post("capsules/search", json=search_params.to_dict())
+
+        return CapsuleSearchResults.from_dict(res.json())

--- a/src/codeocean/capsule.py
+++ b/src/codeocean/capsule.py
@@ -17,6 +17,10 @@ class CapsuleStatus(StrEnum):
     Published = "published"
     Verified = "verified"
 
+class CapsuleSortBy(StrEnum):
+    Created = "created"
+    LastAccessed = "last_accessed"
+    Name = "name"
 
 @dataclass_json
 @dataclass(frozen=True)
@@ -58,7 +62,7 @@ class CapsuleSearchParams:
     limit: Optional[int] = None
     sort_field: Optional[CapsuleSortBy] = None
     sort_order: Optional[SortOrder] = None
-    ownership: Optional[CapsuleOwnership] = None
+    ownership: Optional[Ownership] = None
     status: Optional[CapsuleStatus] = None
     favorite: Optional[bool] = None
     archived: Optional[bool] = None

--- a/src/codeocean/capsule.py
+++ b/src/codeocean/capsule.py
@@ -5,6 +5,7 @@ from dataclasses_json import dataclass_json
 from typing import Optional
 from requests_toolbelt.sessions import BaseUrlSession
 
+from codeocean.components import SortOrder, SearchFilter
 from codeocean.computation import Computation
 from codeocean.data_asset import DataAssetAttachParams, DataAssetAttachResults
 from codeocean.enum import StrEnum
@@ -17,10 +18,18 @@ class CapsuleStatus(StrEnum):
     Published = "published"
     Verified = "verified"
 
+
 class CapsuleSortBy(StrEnum):
     Created = "created"
     LastAccessed = "last_accessed"
     Name = "name"
+
+
+class CapsuleOwnership(StrEnum):
+    Private = "private"
+    Shared = "shared"
+    Created = "created"
+
 
 @dataclass_json
 @dataclass(frozen=True)
@@ -62,7 +71,7 @@ class CapsuleSearchParams:
     limit: Optional[int] = None
     sort_field: Optional[CapsuleSortBy] = None
     sort_order: Optional[SortOrder] = None
-    ownership: Optional[Ownership] = None
+    ownership: Optional[CapsuleOwnership] = None
     status: Optional[CapsuleStatus] = None
     favorite: Optional[bool] = None
     archived: Optional[bool] = None

--- a/src/codeocean/capsule.py
+++ b/src/codeocean/capsule.py
@@ -12,11 +12,8 @@ from codeocean.enum import StrEnum
 
 
 class CapsuleStatus(StrEnum):
-    NonPublished = "non-published"
-    Submitted = "submitted"
-    Publishing = "publishing"
-    Published = "published"
-    Verified = "verified"
+    NonRelease = "non_release"
+    Release = "release"
 
 
 class CapsuleSortBy(StrEnum):
@@ -55,9 +52,9 @@ class Capsule:
     cloned_from_url: Optional[str] = None
     description: Optional[str] = None
     field: Optional[str] = None
-    keywords: Optional[list[str]] = None
+    tags: Optional[list[str]] = None
     original_capsule: Optional[OriginalCapsuleInfo] = None
-    published_capsule: Optional[str] = None
+    release_capsule: Optional[str] = None
     submission: Optional[dict] = None
     versions: Optional[list[dict]] = None
 

--- a/src/codeocean/components.py
+++ b/src/codeocean/components.py
@@ -69,3 +69,9 @@ class SearchFilter:
     values: Optional[list[str | float]] = None
     range: Optional[SearchFilterRange] = None
     exclude: Optional[bool] = None
+
+
+class Ownership(StrEnum):
+    Private = "private"
+    Shared = "shared"
+    Created = "created"

--- a/src/codeocean/components.py
+++ b/src/codeocean/components.py
@@ -75,3 +75,4 @@ class Ownership(StrEnum):
     Private = "private"
     Shared = "shared"
     Created = "created"
+    

--- a/src/codeocean/components.py
+++ b/src/codeocean/components.py
@@ -75,4 +75,3 @@ class Ownership(StrEnum):
     Private = "private"
     Shared = "shared"
     Created = "created"
-    

--- a/src/codeocean/computation.py
+++ b/src/codeocean/computation.py
@@ -7,6 +7,7 @@ from typing import Optional
 from time import sleep, time
 
 from codeocean.enum import StrEnum
+from codeocean.folder import Folder, DownloadFileURL
 
 
 class ComputationState(StrEnum):
@@ -98,33 +99,6 @@ class RunParams:
     parameters: Optional[list[str]] = None
     named_parameters: Optional[list[NamedRunParam]] = None
     processes: Optional[list[PipelineProcessParams]] = None
-
-
-@dataclass_json
-@dataclass(frozen=True)
-class FolderItem:
-    name: str
-    path: str
-    type: str
-    size: Optional[int] = None
-
-
-@dataclass_json
-@dataclass(frozen=True)
-class Folder:
-    items: list[FolderItem]
-
-
-@dataclass_json
-@dataclass(frozen=True)
-class ListFolderParams:
-    path: str
-
-
-@dataclass_json
-@dataclass(frozen=True)
-class DownloadFileURL:
-    url: str
 
 
 @dataclass

--- a/src/codeocean/computation.py
+++ b/src/codeocean/computation.py
@@ -54,14 +54,15 @@ class Computation:
     id: str
     created: int
     name: str
-    state: ComputationState
     run_time: int
+    state: ComputationState
     cloud_workstation: Optional[bool] = None
     data_assets: Optional[list[InputDataAsset]] = None
-    end_status: Optional[ComputationEndStatus] = None
-    has_results: Optional[bool] = None
     parameters: Optional[list[Param]] = None
     processes: Optional[list[PipelineProcess]] = None
+    end_status: Optional[ComputationEndStatus] = None
+    exit_code: Optional[int] = None
+    has_results: Optional[bool] = None
 
 
 @dataclass_json

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -80,16 +80,18 @@ class DataAsset:
     state: DataAssetState
     type: DataAssetType
     last_used: int
-    app_parameters: Optional[list[AppParameter]] = None
-    custom_metadata: Optional[dict] = None
-    description: Optional[str] = None
-    failure_reason: Optional[str] = None
     files: Optional[int] = None
-    provenance: Optional[Provenance] = None
     size: Optional[int] = None
-    source_bucket: Optional[SourceBucket] = None
+    description: Optional[str] = None
     tags: Optional[list[str]] = None
+    provenance: Optional[Provenance] = None
+    source_bucket: Optional[SourceBucket] = None
+    custom_metadata: Optional[dict] = None
+    app_parameters: Optional[list[AppParameter]] = None
     contained_data_assets: Optional[list[ContainedDataAsset]] = None
+    last_transferred: Optional[int] = None
+    transfer_error: Optional[str] = None
+    failure_reason: Optional[str] = None
 
 
 @dataclass_json
@@ -223,6 +225,13 @@ class ContainedDataAsset:
     id: Optional[str] = None
     mount: Optional[str] = None
     size: Optional[int] = None
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class TransferDataParams:
+    target: Target
+    force: Optional[bool] = None
 
 
 @dataclass

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -204,6 +204,7 @@ class DataAssetSearchParams:
     archived: bool
     favorite: bool
     query: Optional[str] = None
+    next_token: Optional[str] = None
     sort_field: Optional[DataAssetSortBy] = None
     sort_order: Optional[SortOrder] = None
     type: Optional[DataAssetType] = None
@@ -217,6 +218,7 @@ class DataAssetSearchParams:
 class DataAssetSearchResults:
     has_more: bool
     results: list[DataAsset]
+    next_token: Optional[str] = None
 
 
 @dataclass_json

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -28,10 +28,10 @@ class DataAssetState(StrEnum):
 @dataclass_json
 @dataclass(frozen=True)
 class Provenance:
-    commit: str
-    run_script: str
-    docker_image: str
-    capsule: str
+    commit: Optional[str] = None
+    run_script: Optional[str] = None
+    docker_image: Optional[str] = None
+    capsule: Optional[str] = None
     data_assets: Optional[list[str]] = None
 
 

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -325,3 +325,9 @@ class DataAssets:
         )
 
         return DownloadFileURL.from_dict(res.json())
+    
+    def transfer_data_asset(self, data_asset_id: str, transfer_params: TransferDataParams):
+        self.client.post(
+            f"data_assets/{data_asset_id}/transfer", 
+            json=transfer_params.to_dict()
+        )

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -15,6 +15,7 @@ class DataAssetType(StrEnum):
     Dataset = "dataset"
     Result = "result"
     Combined = "combined"
+    Model = "model"
 
 
 class DataAssetState(StrEnum):

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -9,6 +9,7 @@ from typing import Optional
 from codeocean.components import Ownership, SortOrder, SearchFilter, Permissions
 from codeocean.computation import PipelineProcess, Param
 from codeocean.enum import StrEnum
+from codeocean.folder import Folder, DownloadFileURL
 
 
 class DataAssetType(StrEnum):
@@ -298,3 +299,20 @@ class DataAssets:
         res = self.client.post("data_assets/search", json=search_params.to_dict())
 
         return DataAssetSearchResults.from_dict(res.json())
+    
+    def list_data_asset_files(self, data_asset_id: str, path: str = "") -> Folder:
+        data = {
+            "path": path,
+        }
+
+        res = self.client.post(f"data_assets/{data_asset_id}/files", json=data)
+
+        return Folder.from_dict(res.json())
+
+    def get_data_asset_file_download_url(self, data_asset_id: str, path: str) -> DownloadFileURL:
+        res = self.client.get(
+            f"data_assets/{data_asset_id}/files/download_url",
+            params={"path": path},
+        )
+
+        return DownloadFileURL.from_dict(res.json())

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -194,17 +194,17 @@ class DataAssetSearchOrigin(StrEnum):
 @dataclass_json
 @dataclass(frozen=True)
 class DataAssetSearchParams:
-    limit: Optional[int] = None
-    offset: Optional[int] = None
-    archived: Optional[bool] = None
-    favorite: Optional[bool] = None
     query: Optional[str] = None
     next_token: Optional[str] = None
+    offset: Optional[int] = None
+    limit: Optional[int] = None
     sort_field: Optional[DataAssetSortBy] = None
     sort_order: Optional[SortOrder] = None
     type: Optional[DataAssetType] = None
     ownership: Optional[Ownership] = None
     origin: Optional[DataAssetSearchOrigin] = None
+    favorite: Optional[bool] = None
+    archived: Optional[bool] = None
     filters: Optional[list[SearchFilter]] = None
 
 

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -299,7 +299,7 @@ class DataAssets:
         res = self.client.post("data_assets/search", json=search_params.to_dict())
 
         return DataAssetSearchResults.from_dict(res.json())
-    
+
     def list_data_asset_files(self, data_asset_id: str, path: str = "") -> Folder:
         data = {
             "path": path,

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -199,10 +199,10 @@ class DataAssetSearchOrigin(StrEnum):
 @dataclass_json
 @dataclass(frozen=True)
 class DataAssetSearchParams:
-    limit: int
-    offset: int
-    archived: bool
-    favorite: bool
+    limit: Optional[int] = None
+    offset: Optional[int] = None
+    archived: Optional[bool] = None
+    favorite: Optional[bool] = None
     query: Optional[str] = None
     next_token: Optional[str] = None
     sort_field: Optional[DataAssetSortBy] = None

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -6,7 +6,7 @@ from requests_toolbelt.sessions import BaseUrlSession
 from time import sleep, time
 from typing import Optional
 
-from codeocean.components import SortOrder, SearchFilter, Permissions
+from codeocean.components import Ownership, SortOrder, SearchFilter, Permissions
 from codeocean.computation import PipelineProcess, Param
 from codeocean.enum import StrEnum
 
@@ -186,12 +186,6 @@ class DataAssetSortBy(StrEnum):
     Size = "size"
 
 
-class DataAssetOwnership(StrEnum):
-    Private = "private"
-    Shared = "shared"
-    Created = "created"
-
-
 class DataAssetSearchOrigin(StrEnum):
     Internal = "internal"
     External = "external"
@@ -209,7 +203,7 @@ class DataAssetSearchParams:
     sort_field: Optional[DataAssetSortBy] = None
     sort_order: Optional[SortOrder] = None
     type: Optional[DataAssetType] = None
-    ownership: Optional[DataAssetOwnership] = None
+    ownership: Optional[Ownership] = None
     origin: Optional[DataAssetSearchOrigin] = None
     filters: Optional[list[SearchFilter]] = None
 

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -325,9 +325,9 @@ class DataAssets:
         )
 
         return DownloadFileURL.from_dict(res.json())
-    
+
     def transfer_data_asset(self, data_asset_id: str, transfer_params: TransferDataParams):
         self.client.post(
-            f"data_assets/{data_asset_id}/transfer", 
+            f"data_assets/{data_asset_id}/transfer",
             json=transfer_params.to_dict()
         )

--- a/src/codeocean/folder.py
+++ b/src/codeocean/folder.py
@@ -30,4 +30,3 @@ class ListFolderParams:
 @dataclass(frozen=True)
 class DownloadFileURL:
     url: str
-    

--- a/src/codeocean/folder.py
+++ b/src/codeocean/folder.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses_json import dataclass_json
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class FolderItem:
+    name: str
+    path: str
+    type: str
+    size: Optional[int] = None
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class Folder:
+    items: list[FolderItem]
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class ListFolderParams:
+    path: str
+
+
+@dataclass_json
+@dataclass(frozen=True)
+class DownloadFileURL:
+    url: str

--- a/src/codeocean/folder.py
+++ b/src/codeocean/folder.py
@@ -30,3 +30,4 @@ class ListFolderParams:
 @dataclass(frozen=True)
 class DownloadFileURL:
     url: str
+    


### PR DESCRIPTION
- New Transfer Data Asset API.
     - Including two new fields in the Get Data Asset API - `last_transferred` & `transfer_error`.
- New APIs for listing & downloading Internal Data Asset files.
- New Capsule Search API.
- Get Capsule API - Fields that were renamed:
     - `published_capsule` --> `release_capsule`
     - `keywords` --> `tags`
     - `version.publish_time` --> `version.release_time`
- Data Asset Search API - New `next_token` field for paging.
- Two new DA types, `combined` & `model`, in both Get Data Asset API response and Data Asset Search API request.
- New `exit_code` field in Get Computation API response
- fix: [make all provenance fields optional in line with open API spec](https://github.com/codeocean/codeocean-sdk-python/commit/10535ced76e638ce457fe3acff59291fc70230a4)