### PR TITLE
feat: adds paginated search method to data asset api

### DIFF
--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -332,15 +332,17 @@ class DataAssets:
             json=transfer_params.to_dict()
         )
 
-    def paginate_search(self, data_asset_search_params: DataAssetSearchParams) -> Iterator[DataAsset]:
-        has_more = True
-        search_params = data_asset_search_params.to_dict()
-        while has_more:
+    def search_data_assets_iterator(self, search_params: DataAssetSearchParams) -> Iterator[DataAsset]:
+        params = search_params.to_dict()
+        while True:
             response = self.search_data_assets(
-                search_params=DataAssetSearchParams(**search_params)
+                search_params=DataAssetSearchParams(**params)
             )
-            next_token = response.next_token
-            has_more = response.has_more
-            search_params["next_token"] = next_token
+
             for result in response.results:
                 yield result
+                
+            if not response.has_more:
+                return
+                
+            params["next_token"] = response.next_token

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -4,7 +4,7 @@ from dataclasses_json import dataclass_json
 from dataclasses import dataclass
 from requests_toolbelt.sessions import BaseUrlSession
 from time import sleep, time
-from typing import Optional
+from typing import Optional, Iterator
 
 from codeocean.components import Ownership, SortOrder, SearchFilter, Permissions
 from codeocean.computation import PipelineProcess, Param
@@ -331,3 +331,15 @@ class DataAssets:
             f"data_assets/{data_asset_id}/transfer",
             json=transfer_params.to_dict()
         )
+
+    def paginate_search(self, data_asset_search_params: DataAssetSearchParams) -> Iterator[list[DataAsset]]:
+        has_more = True
+        search_params = data_asset_search_params.to_dict()
+        while has_more:
+            response = self.search_data_assets(
+                search_params=DataAssetSearchParams(**search_params)
+            )
+            next_token = response.next_token
+            has_more = response.has_more
+            search_params["next_token"] = next_token
+            yield response.results

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -332,7 +332,7 @@ class DataAssets:
             json=transfer_params.to_dict()
         )
 
-    def paginate_search(self, data_asset_search_params: DataAssetSearchParams) -> Iterator[list[DataAsset]]:
+    def paginate_search(self, data_asset_search_params: DataAssetSearchParams) -> Iterator[DataAsset]:
         has_more = True
         search_params = data_asset_search_params.to_dict()
         while has_more:
@@ -342,4 +342,5 @@ class DataAssets:
             next_token = response.next_token
             has_more = response.has_more
             search_params["next_token"] = next_token
-            yield response.results
+            for result in response.results:
+                yield result

--- a/src/codeocean/data_asset.py
+++ b/src/codeocean/data_asset.py
@@ -309,6 +309,21 @@ class DataAssets:
 
         return DataAssetSearchResults.from_dict(res.json())
 
+    def search_data_assets_iterator(self, search_params: DataAssetSearchParams) -> Iterator[DataAsset]:
+        params = search_params.to_dict()
+        while True:
+            response = self.search_data_assets(
+                search_params=DataAssetSearchParams(**params)
+            )
+
+            for result in response.results:
+                yield result
+
+            if not response.has_more:
+                return
+
+            params["next_token"] = response.next_token
+
     def list_data_asset_files(self, data_asset_id: str, path: str = "") -> Folder:
         data = {
             "path": path,
@@ -331,18 +346,3 @@ class DataAssets:
             f"data_assets/{data_asset_id}/transfer",
             json=transfer_params.to_dict()
         )
-
-    def search_data_assets_iterator(self, search_params: DataAssetSearchParams) -> Iterator[DataAsset]:
-        params = search_params.to_dict()
-        while True:
-            response = self.search_data_assets(
-                search_params=DataAssetSearchParams(**params)
-            )
-
-            for result in response.results:
-                yield result
-                
-            if not response.has_more:
-                return
-                
-            params["next_token"] = response.next_token


### PR DESCRIPTION
Closes #23 

- Adds pagination method to data asset api
- Example usage:

```python
import os
from codeocean.data_asset import DataAssetSearchParams, DataAssetType
from codeocean import CodeOcean
from urllib3.util import Retry


def run_job():

    domain = os.getenv("CO_DOMAIN")
    token = os.getenv("CO_TOKEN")
    retry = Retry(
        total=5,
        backoff_factor=1,
        status_forcelist=[429],
        allowed_methods=["GET", "POST"]
    )
    client = CodeOcean(domain=domain, token=token, retries=retry)
    search_params = DataAssetSearchParams(
        limit=1000,
        archived=False,
        favorite=False,
        type=DataAssetType.Dataset,
    )

    paginator = client.data_assets.search_data_assets_iterator(
        data_asset_search_params=search_params
    )
    for data_asset in paginator:
          print(data_asset.id)


if __name__ == "__main__":
    run_job()

```