### PR TITLE
feat: Add Min-Server-Version header support

### DIFF
--- a/src/codeocean/client.py
+++ b/src/codeocean/client.py
@@ -36,7 +36,10 @@ class CodeOcean:
     def __post_init__(self):
         self.session = BaseUrlSession(base_url=f"{self.domain}/api/v1/")
         self.session.auth = (self.token, "")
-        self.session.headers.update({"Content-Type": "application/json"})
+        self.session.headers.update({
+            "Content-Type": "application/json",
+            "Min-Server-Version": "3.6.0",
+        })
         if self.agent_id:
             self.session.headers.update({"Agent-Id": self.agent_id})
         self.session.hooks["response"] = [

--- a/src/codeocean/client.py
+++ b/src/codeocean/client.py
@@ -10,9 +10,6 @@ from codeocean.capsule import Capsules
 from codeocean.computation import Computations
 from codeocean.data_asset import DataAssets
 
-# Minimum server version required by this SDK
-MIN_SERVER_VERSION = "3.6.0"
-
 
 @dataclass
 class CodeOcean:
@@ -36,12 +33,15 @@ class CodeOcean:
     retries: Optional[Retry | int] = 0
     agent_id: Optional[str] = None
 
+    # Minimum server version required by this SDK
+    MIN_SERVER_VERSION = "3.6.0"
+
     def __post_init__(self):
         self.session = BaseUrlSession(base_url=f"{self.domain}/api/v1/")
         self.session.auth = (self.token, "")
         self.session.headers.update({
             "Content-Type": "application/json",
-            "Min-Server-Version": MIN_SERVER_VERSION,
+            "Min-Server-Version": CodeOcean.MIN_SERVER_VERSION,
         })
         if self.agent_id:
             self.session.headers.update({"Agent-Id": self.agent_id})

--- a/src/codeocean/client.py
+++ b/src/codeocean/client.py
@@ -10,6 +10,9 @@ from codeocean.capsule import Capsules
 from codeocean.computation import Computations
 from codeocean.data_asset import DataAssets
 
+# Minimum server version required by this SDK
+MIN_SERVER_VERSION = "3.6.0"
+
 
 @dataclass
 class CodeOcean:
@@ -38,7 +41,7 @@ class CodeOcean:
         self.session.auth = (self.token, "")
         self.session.headers.update({
             "Content-Type": "application/json",
-            "Min-Server-Version": "3.6.0",
+            "Min-Server-Version": MIN_SERVER_VERSION,
         })
         if self.agent_id:
             self.session.headers.update({"Agent-Id": self.agent_id})

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch
 from urllib3.util import Retry
 
-from codeocean.client import CodeOcean, MIN_SERVER_VERSION
+from codeocean.client import CodeOcean
 
 
 class TestClient(unittest.TestCase):
@@ -32,7 +32,7 @@ class TestClient(unittest.TestCase):
         self.assertIn("Content-Type", headers)
         self.assertEqual(headers["Content-Type"], "application/json")
         self.assertIn("Min-Server-Version", headers)
-        self.assertEqual(headers["Min-Server-Version"], MIN_SERVER_VERSION)
+        self.assertEqual(headers["Min-Server-Version"], CodeOcean.MIN_SERVER_VERSION)
 
     @patch("codeocean.client.TCPKeepAliveAdapter")
     def test_retry_configuration_types(self, mock_adapter):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch
 from urllib3.util import Retry
 
-from codeocean.client import CodeOcean
+from codeocean.client import CodeOcean, MIN_SERVER_VERSION
 
 
 class TestClient(unittest.TestCase):
@@ -31,6 +31,8 @@ class TestClient(unittest.TestCase):
         headers = client.session.headers
         self.assertIn("Content-Type", headers)
         self.assertEqual(headers["Content-Type"], "application/json")
+        self.assertIn("Min-Server-Version", headers)
+        self.assertEqual(headers["Min-Server-Version"], MIN_SERVER_VERSION)
 
     @patch("codeocean.client.TCPKeepAliveAdapter")
     def test_retry_configuration_types(self, mock_adapter):


### PR DESCRIPTION
Code Ocean API now supports enforcing minimum server version requirements through the `Min-Server-Version` header. When a client specifies this header, the server will validate that its version meets the minimum requirement before processing the request. When the server version is insufficient or the header format is invalid, the API returns 400 Bad Request.


