### PR TITLE
Bump version to 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+## 0.15.0 (2026-04-10)
+- [#69](https://github.com/codeocean/codeocean-sdk-python/pull/69) feat: Code Ocean version 4.3 functionality
+- [#68](https://github.com/codeocean/codeocean-sdk-python/pull/68) feat: add get_permissions method for capsules, pipelines, data assets
+- **Minimum Code Ocean platform version updated to `4.3.0`.**  
+
 ## 0.14.0 (2026-01-29)
 - [#66](https://github.com/codeocean/codeocean-sdk-python/pull/66) feat: Code Ocean version 4.2 functionality
 - **Minimum Code Ocean platform version updated to `4.2.0`.**  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "codeocean"
-version = "0.14.0"
+version = "0.15.0"
 authors = [
   { name="Code Ocean", email="dev@codeocean.com" },
 ]


### PR DESCRIPTION
## Summary
- Bump version to `0.15.0` in `pyproject.toml`
- Update `CHANGELOG.md` with entries for PRs #68 and #69

## Changes
- [#69](https://github.com/codeocean/codeocean-sdk-python/pull/69) feat: Code Ocean version 4.3 functionality
- [#68](https://github.com/codeocean/codeocean-sdk-python/pull/68) feat: add get_permissions method for capsules, pipelines, data assets
- Minimum Code Ocean platform version updated to `4.3.0`

## Test plan
- [ ] Verify version is `0.15.0` in `pyproject.toml`
- [ ] Verify `CHANGELOG.md` entry for `0.15.0` is correct
- [ ] After merge: tag `v0.15.0` and push to trigger CircleCI release

🤖 Generated with [Claude Code](https://claude.com/claude-code)