### PR TITLE
Bump version to 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## 0.16.0 (2026-06-08)
+- [#71](https://github.com/codeocean/codeocean-sdk-python/pull/71) feat: add Git sync support for capsules and pipelines
+- **Minimum Code Ocean platform version updated to `4.6.0`.**
+
 ## 0.15.0 (2026-04-10)
 - [#69](https://github.com/codeocean/codeocean-sdk-python/pull/69) feat: Code Ocean version 4.3 functionality
 - [#68](https://github.com/codeocean/codeocean-sdk-python/pull/68) feat: add get_permissions method for capsules, pipelines, data assets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "codeocean"
-version = "0.15.0"
+version = "0.16.0"
 authors = [
   { name="Code Ocean", email="dev@codeocean.com" },
 ]


### PR DESCRIPTION
Release 0.16.0.

- Bump version `0.15.0` → `0.16.0` in `pyproject.toml`.
- Add CHANGELOG entry for #71 (Git sync support for capsules and pipelines).
- `MIN_SERVER_VERSION` is already `4.6.0` (set in #71), so no client change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)