### PR TITLE
docs: add human approval gate to release process

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,11 +1,18 @@
 # Version Release Process
 
+> **⚠️ Automated agents: stop after step 1.** Open the release PR, then hand
+> control back to the user. A human must review, approve, and merge the PR
+> (step 2). Do **not** merge the PR, create the tag, or push the tag on your
+> own — pushing the tag publishes to PyPI and **cannot be undone**. Only
+> continue past step 1 after the user explicitly tells you to proceed.
+
 1. Open a PR with the following changes:
     1. Bump the version in [pyproject.toml](pyproject.toml).
     1. Update the [CHANGELOG.md](CHANGELOG.md).
     1. If the change requires a newer Code Ocean server version, update `MIN_SERVER_VERSION` in [client.py](src/codeocean/client.py).
     1. Commit the updates with the message `Bump version to X.Y.Z`.
-1. Merge the PR.
+1. **Review, approve, and merge the PR.** This is a manual step performed by a
+   human after CI passes — it is the approval gate for the release.
 1. Locally, sync your clone with GitHub:
     ```
     git fetch origin

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,11 +1,5 @@
 # Version Release Process
 
-> **⚠️ Automated agents: stop after step 1.** Open the release PR, then hand
-> control back to the user. A human must review, approve, and merge the PR
-> (step 2). Do **not** merge the PR, create the tag, or push the tag on your
-> own — pushing the tag publishes to PyPI and **cannot be undone**. Only
-> continue past step 1 after the user explicitly tells you to proceed.
-
 1. Open a PR with the following changes:
     1. Bump the version in [pyproject.toml](pyproject.toml).
     1. Update the [CHANGELOG.md](CHANGELOG.md).
@@ -13,6 +7,12 @@
     1. Commit the updates with the message `Bump version to X.Y.Z`.
 1. **Review, approve, and merge the PR.** This is a manual step performed by a
    human after CI passes — it is the approval gate for the release.
+
+    > **⚠️ Automated agents: stop after step 1.** Open the release PR, then hand
+    > control back to the user. A human performs this step. Do **not** merge the
+    > PR, create the tag, or push the tag on your own — pushing the tag publishes
+    > to PyPI and **cannot be undone**. Only continue to the steps below after the
+    > user explicitly tells you to proceed.
 1. Locally, sync your clone with GitHub:
     ```
     git fetch origin

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,5 +28,4 @@
     git push origin vX.Y.Z
     ```
 
-    This will trigger a workflow on CircleCI that will generate a GitHub release
-    and publish the new version to PyPI.
+    This will trigger a workflow on CircleCI that will publish the new version to PyPI.


### PR DESCRIPTION
## Summary

Clarifies `RELEASE.md` so automated agents don't run the full release unattended.

- Adds a prominent note: agents must **stop after step 1** (opening the release PR) and hand control back to a human.
- Clarifies step 2 ("Merge the PR") as a **manual human approval gate** performed after CI passes.
- Notes that pushing the release tag publishes to PyPI and is **irreversible**.

### Why

During the 0.16.0 release, the bump PR was merged and the tag pushed (publishing to PyPI) without waiting for human approval, because the doc listed merge/tag/push as plain steps with no actor or stop-gate. This makes the gate explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)